### PR TITLE
Permissions related to post creation

### DIFF
--- a/hasura/hasura-migrations/migrations/1574971921162_update_permission_user_public_table_replies/down.yaml
+++ b/hasura/hasura-migrations/migrations/1574971921162_update_permission_user_public_table_replies/down.yaml
@@ -1,0 +1,23 @@
+- args:
+    role: user
+    table:
+      name: replies
+      schema: public
+  type: drop_select_permission
+- args:
+    permission:
+      allow_aggregations: false
+      columns:
+      - author_id
+      - id
+      - post_id
+      - content
+      - created_at
+      - updated_at
+      computed_fields: []
+      filter: {}
+    role: user
+    table:
+      name: replies
+      schema: public
+  type: create_select_permission

--- a/hasura/hasura-migrations/migrations/1574971921162_update_permission_user_public_table_replies/up.yaml
+++ b/hasura/hasura-migrations/migrations/1574971921162_update_permission_user_public_table_replies/up.yaml
@@ -1,0 +1,23 @@
+- args:
+    role: user
+    table:
+      name: replies
+      schema: public
+  type: drop_select_permission
+- args:
+    permission:
+      allow_aggregations: true
+      columns:
+      - author_id
+      - id
+      - post_id
+      - content
+      - created_at
+      - updated_at
+      computed_fields: []
+      filter: {}
+    role: user
+    table:
+      name: replies
+      schema: public
+  type: create_select_permission

--- a/hasura/hasura-migrations/migrations/1574977595328_update_permission_user_public_table_posts/down.yaml
+++ b/hasura/hasura-migrations/migrations/1574977595328_update_permission_user_public_table_posts/down.yaml
@@ -1,0 +1,32 @@
+- args:
+    role: user
+    table:
+      name: posts
+      schema: public
+  type: drop_insert_permission
+- args:
+    permission:
+      check:
+        _and:
+        - author_id:
+            _eq: X-Hasura-User-Id
+        - category_id:
+            _nin:
+            - 1
+            - 3
+      columns:
+      - author_id
+      - category_id
+      - content
+      - creation_date
+      - modification_date
+      - title
+      localPresets:
+      - key: ""
+        value: ""
+      set: {}
+    role: user
+    table:
+      name: posts
+      schema: public
+  type: create_insert_permission

--- a/hasura/hasura-migrations/migrations/1574977595328_update_permission_user_public_table_posts/up.yaml
+++ b/hasura/hasura-migrations/migrations/1574977595328_update_permission_user_public_table_posts/up.yaml
@@ -1,0 +1,27 @@
+- args:
+    role: user
+    table:
+      name: posts
+      schema: public
+  type: drop_insert_permission
+- args:
+    permission:
+      check:
+        author_id:
+          _eq: X-Hasura-User-Id
+      columns:
+      - author_id
+      - category_id
+      - content
+      - creation_date
+      - modification_date
+      - title
+      localPresets:
+      - key: ""
+        value: ""
+      set: {}
+    role: user
+    table:
+      name: posts
+      schema: public
+  type: create_insert_permission


### PR DESCRIPTION
- removes a restrictions on `posts` to `users` to allow inserting posts for any category.
- allow aggregation for `users` on replies
- related to https://github.com/Tbaut/governance-platform/pull/28